### PR TITLE
Fix rate limiter conversion bug

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -235,8 +235,14 @@ server_t *server_create(const server_config_t *config) {
     server->config = *config;
     
     /* Initialize rate limiter */
+    /* Convert per-minute rate limit to per-second, rounding up to avoid zero */
+    unsigned int per_sec = (config->max_requests + 59) / 60;
+    if (per_sec == 0) {
+        per_sec = 1;
+    }
+
     rate_limit_config_t rate_config = {
-        .requests_per_second = config->max_requests / 60,  // Convert per minute to per second
+        .requests_per_second = per_sec,
         .burst_size = config->max_requests,
         .window_seconds = 60
     };


### PR DESCRIPTION
## Summary
- ensure the rate limiter calculates `requests_per_second` correctly by rounding up

## Testing
- `make test` *(fails: Response contains error message / integration tests hang)*

------
https://chatgpt.com/codex/tasks/task_e_683f44cfee888327acf193fb265c6c51